### PR TITLE
Update index.js for Message Delivery Receipt

### DIFF
--- a/packages/xep-0184-mdr/index.js
+++ b/packages/xep-0184-mdr/index.js
@@ -1,6 +1,4 @@
 
- */
-// @flow
 'use strict';
 
 const {EventEmitter} = require('@xmpp/events');


### PR DESCRIPTION
The index.js for Message Delivery Receipt plugin was showing a syntax error at the start of the file. The error was most likely due to the "end comment characters */".